### PR TITLE
add research endpoint usage changes

### DIFF
--- a/UI/src/components/DailyDigestReport.tsx
+++ b/UI/src/components/DailyDigestReport.tsx
@@ -256,7 +256,7 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                     <CardContent>
                       <div className="bg-gradient-to-r from-tavily-blue/5 to-tavily-light-blue/5 p-4 rounded-xl border border-tavily-light-blue shadow-sm">
                         <p className="text-gray-700 leading-relaxed text-sm mb-4">{selectedStock.current_performance}</p>
-                        <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Annualized CAGR</span>: {selectedStock.tavily_metrics?.annualized_cagr}%</p>
+                        {selectedStock.tavily_metrics?.annualized_cagr && <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Annualized CAGR</span>: {selectedStock.tavily_metrics?.annualized_cagr}%</p>}
                       </div>
                     </CardContent>
                   </Card>
@@ -274,8 +274,8 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                     <CardContent>
                       <div className="bg-gradient-to-r from-tavily-red/5 to-tavily-light-red/5 p-4 rounded-xl border border-tavily-light-red shadow-sm">
                         <p className="text-gray-700 leading-relaxed text-sm mb-4">{selectedStock.risk_assessment}</p>
-                        <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Sharpe Ratio</span>: {selectedStock.tavily_metrics?.sharpe_ratio}</p>
-                        <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Max Drawdown</span>: {selectedStock.tavily_metrics?.max_drawdown}%</p>
+                        {selectedStock.tavily_metrics?.sharpe_ratio && <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Sharpe Ratio</span>: {selectedStock.tavily_metrics?.sharpe_ratio}</p>}
+                        {selectedStock.tavily_metrics?.max_drawdown && <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Max Drawdown</span>: {selectedStock.tavily_metrics?.max_drawdown}%</p>}
                       </div>
                     </CardContent>
                   </Card>
@@ -293,8 +293,8 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                     <CardContent>
                       <div className="bg-gradient-to-r from-tavily-light-yellow/10 to-tavily-light-yellow/5 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm">
                         <p className="text-gray-700 leading-relaxed text-sm mb-4">{selectedStock.price_outlook}</p>
-                        <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Price High (2-Year)</span>: ${selectedStock.tavily_metrics?.two_year_price_high}</p>
-                        <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Price Low (2-Year)</span>: ${selectedStock.tavily_metrics?.two_year_price_low}</p>
+                        {selectedStock.tavily_metrics?.two_year_price_high && <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Price High (2-Year)</span>: ${selectedStock.tavily_metrics?.two_year_price_high}</p>}
+                        {selectedStock.tavily_metrics?.two_year_price_low && <p className="text-gray-700 leading-relaxed text-sm"><span className="font-bold">Price Low (2-Year)</span>: ${selectedStock.tavily_metrics?.two_year_price_low}</p>}
                       </div>
                     </CardContent>
                   </Card>

--- a/UI/src/components/DailyDigestReport.tsx
+++ b/UI/src/components/DailyDigestReport.tsx
@@ -175,14 +175,6 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                             </div>
                           )}
 
-                          {/* Latest Close Price */}
-                          {selectedStock.tavily_metrics?.latest_close_price && (
-                            <div className="bg-tavily-light-yellow/20 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm hover:shadow-md transition-all duration-200">
-                              <div className="text-base text-gray-600 font-medium mb-1">Close Price</div>
-                              <div className="text-base font-bold text-gray-900">${selectedStock.tavily_metrics?.latest_close_price?.toFixed(2)}</div>
-                            </div>
-                          )}
-
                           {/* Trading Volume */}
                           {/* {selectedStock.tavily_metrics?.trading_volume && (
                           <div className="bg-tavily-light-yellow/20 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm hover:shadow-md transition-all duration-200">
@@ -223,60 +215,6 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                         </div>
                       </div>
                     )}
-
-                    {/* Tavily Metrics Section */}
-                    {/* {selectedStock.tavily_metrics && (
-                      <div className="mb-8">
-                        <h4 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
-                          <BarChart3 className="h-5 w-5 text-tavily-blue" />
-                          Advanced Metrics
-                        </h4>
-                        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-                          {selectedStock.tavily_metrics.sharpe_ratio !== undefined && (
-                            <div className="bg-gradient-to-r from-tavily-blue/5 to-tavily-light-blue/5 p-4 rounded-xl border border-tavily-light-blue shadow-sm hover:shadow-md transition-all duration-200">
-                              <div className="text-base text-gray-600 font-medium mb-1">Sharpe Ratio</div>
-                              <div className="text-base font-bold text-gray-900">{selectedStock.tavily_metrics.sharpe_ratio.toFixed(2)}</div>
-                            </div>
-                          )}
-                          {selectedStock.tavily_metrics.annualized_cagr !== undefined && (
-                            <div className="bg-tavily-light-yellow/20 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm hover:shadow-md transition-all duration-200">
-                              <div className="text-base text-gray-600 font-medium mb-1">Annualized CAGR</div>
-                              <div className="text-base font-bold text-gray-900">{(selectedStock.tavily_metrics.annualized_cagr * 100).toFixed(2)}%</div>
-                            </div>
-                          )}
-                          {selectedStock.tavily_metrics.latest_open_price !== undefined && (
-                            <div className="bg-gradient-to-r from-tavily-blue/5 to-tavily-light-blue/5 p-4 rounded-xl border border-tavily-light-blue shadow-sm hover:shadow-md transition-all duration-200">
-                              <div className="text-base text-gray-600 font-medium mb-1">Latest Open</div>
-                              <div className="text-base font-bold text-gray-900">${selectedStock.tavily_metrics.latest_open_price.toFixed(2)}</div>
-                            </div>
-                          )}
-                          {selectedStock.tavily_metrics.latest_close_price !== undefined && (
-                            <div className="bg-gradient-to-r from-tavily-blue/5 to-tavily-light-blue/5 p-4 rounded-xl border border-tavily-light-blue shadow-sm hover:shadow-md transition-all duration-200">
-                              <div className="text-base text-gray-600 font-medium mb-1">Latest Close</div>
-                              <div className="text-base font-bold text-gray-900">${selectedStock.tavily_metrics.latest_close_price.toFixed(2)}</div>
-                            </div>
-                          )}
-                          {selectedStock.tavily_metrics.trading_volume !== undefined && (
-                            <div className="bg-tavily-light-yellow/20 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm hover:shadow-md transition-all duration-200">
-                              <div className="text-base text-gray-600 font-medium mb-1">Trading Volume</div>
-                              <div className="text-base font-bold text-gray-900">{selectedStock.tavily_metrics.trading_volume.toLocaleString()}</div>
-                            </div>
-                          )}
-                          {(selectedStock.tavily_metrics.two_year_price_high !== undefined) && (
-                            <div className="bg-gradient-to-r from-tavily-blue/5 to-tavily-light-blue/5 p-4 rounded-xl border border-tavily-light-blue shadow-sm hover:shadow-md transition-all duration-200">
-                              <div className="text-base text-gray-600 font-medium mb-1">2-Year High</div>
-                              <div className="text-base font-bold text-gray-900">${selectedStock.tavily_metrics.two_year_price_high.toFixed(2)}</div>
-                            </div>
-                          )}
-                          {(selectedStock.tavily_metrics.two_year_price_low !== undefined) && (
-                            <div className="bg-gradient-to-r from-tavily-blue/5 to-tavily-light-blue/5 p-4 rounded-xl border border-tavily-light-blue shadow-sm hover:shadow-md transition-all duration-200">
-                              <div className="text-base text-gray-600 font-medium mb-1">2-Year Low</div>
-                              <div className="text-base font-bold text-gray-900">${selectedStock.tavily_metrics.two_year_price_low.toFixed(2)}</div>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )} */}
 
                   </CardContent>
                 </Card>

--- a/UI/src/components/DailyDigestReport.tsx
+++ b/UI/src/components/DailyDigestReport.tsx
@@ -7,10 +7,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { generateStockDigestPDF } from '@/lib/utils';
 import { StockDigestResponse } from '@/types/stock-digest';
-import { AlertTriangle, ArrowLeft, BarChart3, ChevronDown, Circle, DollarSign, Download, ExternalLink, Globe, Target, TrendingUp } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, BarChart3, ChevronDown, Circle, DollarSign, Download, ExternalLink, TrendingUp } from 'lucide-react';
 import React, { useState } from 'react';
 
 interface DailyDigestReportProps {
@@ -107,31 +106,8 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
           </Button>
         </div>
 
-        {/* Main Content with Tabs */}
-        <Tabs defaultValue="your-stocks" className="w-full">
-          <TabsList className="grid w-full grid-cols-2 mb-4 bg-white/95 backdrop-blur-sm border border-gray-200 shadow-lg rounded-xl p-0">
-            <TabsTrigger
-              value="your-stocks"
-              className="text-base font-medium data-[state=active]:bg-gradient-to-r data-[state=active]:from-tavily-blue data-[state=active]:to-tavily-light-blue data-[state=active]:text-white data-[state=active]:shadow-lg hover:bg-gray-50 transition-all duration-300 rounded-xl"
-            >
-              <div className="flex items-center gap-2">
-                <BarChart3 className="h-4 w-4" />
-                Your Stocks
-              </div>
-            </TabsTrigger>
-            <TabsTrigger
-              value="market-overview"
-              className="text-base font-medium data-[state=active]:bg-gradient-to-r data-[state=active]:from-tavily-blue data-[state=active]:to-tavily-light-blue data-[state=active]:text-white data-[state=active]:shadow-lg hover:bg-gray-50 transition-all duration-300 rounded-xl"
-            >
-              <div className="flex items-center gap-2">
-                <Globe className="h-4 w-4" />
-                Market Overview
-              </div>
-            </TabsTrigger>
-          </TabsList>
-
-          {/* Your Stocks Tab */}
-          <TabsContent value="your-stocks" className="space-y-6 mt-5">
+        {/* Main Content */}
+        <div className="space-y-6 mt-5">
             {/* Stock Selector */}
             <div className="w-1/3 mx-auto">
               <Card className="border-0 shadow-lg bg-tavily-blue/10 backdrop-blur-sm hover:shadow-xl transition-all duration-300">
@@ -182,8 +158,16 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                           <DollarSign className="h-5 w-5 text-tavily-blue" />
                           Financial Metrics
                         </h4> */}
-                        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+                        <div className="grid grid-cols-4 md:grid-cols-4 lg:grid-cols-5 gap-4">
                           {/* Current Price */}
+                          {selectedStock.tavily_metrics?.current_price && (
+                            <div className="bg-tavily-light-yellow/20 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm hover:shadow-md transition-all duration-200">
+                              <div className="text-base text-gray-600 font-medium mb-1">Current Price:</div>
+                              <div className="text-base font-bold text-gray-900">${selectedStock.tavily_metrics?.current_price?.toFixed(2)}</div>
+                            </div>
+                          )}
+
+                          {/* Open Price */}
                           {selectedStock.tavily_metrics?.latest_open_price && (
                             <div className="bg-tavily-light-yellow/20 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm hover:shadow-md transition-all duration-200">
                               <div className="text-base text-gray-600 font-medium mb-1">Open Price:</div>
@@ -208,26 +192,34 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                           )} */}
 
                           {/* Market Cap */}
-                          {/* {selectedStock.tavily_metrics?.market_cap && (
-                          <div className="bg-tavily-light-yellow/20 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm hover:shadow-md transition-all duration-200">
-                            <div className="text-base text-gray-600 font-medium mb-1">Market Cap</div>
-                            <div className="text-base font-bold text-gray-900">
-                              {(() => {
-                                const cap = selectedStock.tavily_metrics?.market_cap;
-                                if (cap == null) return "-";
-                                if (cap >= 1e12) {
-                                  return `$${(cap / 1e12).toFixed(3)}T`;
-                                } else if (cap >= 1e9) {
-                                  return `$${(cap / 1e9).toFixed(3)}B`;
-                                } else if (cap >= 1e6) {
-                                  return `$${(cap / 1e6).toFixed(3)}M`;
-                                } else {
-                                  return `$${cap.toLocaleString()}`;
-                                }
-                              })()}
+                          {selectedStock.market_cap && (
+                            <div className="bg-tavily-light-yellow/20 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm hover:shadow-md transition-all duration-200">
+                              <div className="text-base text-gray-600 font-medium mb-1">Market Cap:</div>
+                              <div className="text-base font-bold text-gray-900">
+                                {(() => {
+                                  const cap = selectedStock.market_cap;
+                                  if (cap == null) return "-";
+                                  if (cap >= 1e12) {
+                                    return `$${(cap / 1e12).toFixed(2)}T`;
+                                  } else if (cap >= 1e9) {
+                                    return `$${(cap / 1e9).toFixed(2)}B`;
+                                  } else if (cap >= 1e6) {
+                                    return `$${(cap / 1e6).toFixed(2)}M`;
+                                  } else {
+                                    return `$${cap.toLocaleString()}`;
+                                  }
+                                })()}
+                              </div>
                             </div>
-                          </div>
-                          )} */}
+                          )}
+
+                          {/* P/E Ratio */}
+                          {selectedStock.pe_ratio && (
+                            <div className="bg-tavily-light-yellow/20 p-4 rounded-xl border border-tavily-light-yellow/30 shadow-sm hover:shadow-md transition-all duration-200">
+                              <div className="text-base text-gray-600 font-medium mb-1">P/E Ratio:</div>
+                              <div className="text-base font-bold text-gray-900">{selectedStock.pe_ratio?.toFixed(2)}</div>
+                            </div>
+                          )}
                         </div>
                       </div>
                     )}
@@ -286,16 +278,6 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                       </div>
                     )} */}
 
-                    {/* Stock Market Overview - Full Width at Top */}
-                    <div className="bg-gradient-to-r from-tavily-blue/5 to-tavily-light-blue/5 px-6 py-4 rounded-xl border border-tavily-light-blue shadow-sm">
-                      <h4 className="font-bold text-gray-900 mb-3 flex items-center gap-3 text-lg">
-                        <div className="p-2 bg-tavily-blue/10 rounded-lg">
-                          <BarChart3 className="h-5 w-5 text-tavily-blue" />
-                        </div>
-                        Stock Overview
-                      </h4>
-                      <p className="text-gray-700 leading-relaxed text-sm">{selectedStock.summary}</p>
-                    </div>
                   </CardContent>
                 </Card>
 
@@ -380,36 +362,6 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                   </Card>
                 </div>
 
-                {/* Final Recommendation */}
-                <div className="bg-gradient-to-r from-slate-100 via-gray-100 to-slate-200 px-6 py-4 rounded-xl border-2 border-dashed border-slate-300 shadow-lg">
-                  <div className="flex items-center gap-3 mb-4">
-                    <div className="p-2 bg-slate-200 rounded-lg">
-                      <Target className="h-5 w-5 text-slate-600" />
-                    </div>
-                    <h4 className="text-lg font-semibold text-slate-800">Final Recommendation</h4>
-                  </div>
-                  <div className="bg-white/80 p-5 rounded-xl border border-slate-200 shadow-sm backdrop-blur-sm">
-                    <p className="text-sm text-slate-800 font-medium leading-relaxed">
-                      {(() => {
-                        const text = selectedStock.recommendation || '';
-                        const firstSeparatorIndex = text.search(/[.\-–—]/);
-                        if (firstSeparatorIndex === -1) {
-                          return text;
-                        }
-                        const before = text.slice(0, firstSeparatorIndex);
-                        const separator = text[firstSeparatorIndex];
-                        const after = text.slice(firstSeparatorIndex + 1);
-                        return (
-                          <>
-                            <span className="text-base"><strong>{before}</strong>{separator}</span>
-                            <span>{after}</span>
-                          </>
-                        );
-                      })()}
-                    </p>
-                  </div>
-                </div>
-
                 {/* Sources Panel for this Stock */}
                 <Card className="border-0 shadow-lg bg-white/95 backdrop-blur-sm hover:shadow-xl transition-all duration-300">
                   <CardHeader>
@@ -489,69 +441,7 @@ export const DailyDigestReport: React.FC<DailyDigestReportProps> = ({
                 </Card>
               </div>
             )}
-          </TabsContent>
-
-          {/* Market Overview Tab */}
-          <TabsContent value="market-overview" className="space-y-6 mt-6">
-            {/* Market Overview */}
-            {stockDigest.market_overview && (
-              <Card className="border-0 shadow-lg bg-gradient-to-r from-tavily-blue/5 to-tavily-light-blue/5 backdrop-blur-sm hover:shadow-xl transition-all duration-300">
-                <CardHeader className="pb-2">
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-tavily-blue/10 rounded-lg">
-                      <Globe className="h-5 w-5 text-tavily-blue" />
-                    </div>
-                    <div>
-                      <CardTitle className="text-lg font-semibold text-gray-900">Portfolio Overview</CardTitle>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="pb-4">
-                  <div className="bg-white/80 p-4 rounded-lg border border-tavily-light-blue shadow-sm">
-                    <p className="text-gray-800 leading-relaxed text-sm">{stockDigest.market_overview}</p>
-                  </div>
-                </CardContent>
-              </Card>
-            )}
-
-            {/* Stock Recommendations */}
-            {stockDigest.ticker_suggestions && Object.keys(stockDigest.ticker_suggestions).length > 0 && (
-              <Card className="border-0 shadow-lg bg-tavily-light-yellow/20 backdrop-blur-sm hover:shadow-xl transition-all duration-300">
-                <CardHeader className="pb-2">
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 bg-tavily-light-red/30 rounded-lg">
-                      <Target className="h-5 w-5 text-tavily-red" />
-                    </div>
-                    <div>
-                      <CardTitle className="text-lg font-semibold text-gray-900">Stock Recommendations</CardTitle>
-                      <CardDescription className="text-sm text-gray-600">
-                        Current analyst picks and trending stocks
-                      </CardDescription>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="pb-4">
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {Object.entries(stockDigest.ticker_suggestions).map(([ticker, reason]) => (
-                      <div
-                        key={ticker}
-                        className="bg-white/80 p-4 rounded-lg border border-tavily-light-yellow/30 hover:bg-white/90 transition-all duration-200 shadow-sm"
-                      >
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="flex items-center gap-2">
-                            <div className="w-2 h-2 bg-gradient-to-r from-tavily-light-yellow to-tavily-light-yellow/70 rounded-full"></div>
-                            <span className="font-bold text-lg text-gray-900">{ticker}</span>
-                          </div>
-                        </div>
-                        <p className="text-sm text-gray-700 leading-relaxed">{reason}</p>
-                      </div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-            )}
-          </TabsContent>
-        </Tabs>
+        </div>
 
 
       </div>

--- a/UI/src/components/TickerInput.tsx
+++ b/UI/src/components/TickerInput.tsx
@@ -2,14 +2,18 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { toast } from '@/hooks/use-toast';
 import { Loader2, Plus, TrendingUp, X } from 'lucide-react';
 import React, { KeyboardEvent, useState } from 'react';
 
+export type ResearchModel = 'mini' | 'pro';
+
 interface TickerInputProps {
   tickers: string[];
   onTickersChange: (tickers: string[]) => void;
-  onGenerateReport: () => void;
+  onGenerateReport: (model: ResearchModel) => void;
   isGenerating: boolean;
 }
 
@@ -20,6 +24,7 @@ export const TickerInput: React.FC<TickerInputProps> = ({
   isGenerating,
 }) => {
   const [inputValue, setInputValue] = useState('');
+  const [researchModel, setResearchModel] = useState<ResearchModel>('mini');
 
   const addTicker = () => {
     const ticker = inputValue.trim().toUpperCase();
@@ -163,9 +168,31 @@ export const TickerInput: React.FC<TickerInputProps> = ({
         </div>
       )}
 
+      {/* Research Model Toggle */}
+      <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+        <div className="space-y-0.5">
+          <Label htmlFor="research-model" className="text-sm font-medium">
+            Research Model
+          </Label>
+          <p className="text-xs text-gray-500">
+            {researchModel === 'pro' ? 'Pro: Deeper analysis, slower' : 'Mini: Fast analysis'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={`text-xs ${researchModel === 'mini' ? 'font-medium' : 'text-gray-400'}`}>Mini</span>
+          <Switch
+            id="research-model"
+            checked={researchModel === 'pro'}
+            onCheckedChange={(checked) => setResearchModel(checked ? 'pro' : 'mini')}
+            disabled={isGenerating}
+          />
+          <span className={`text-xs ${researchModel === 'pro' ? 'font-medium' : 'text-gray-400'}`}>Pro</span>
+        </div>
+      </div>
+
       {/* Generate Button */}
       <Button
-        onClick={onGenerateReport}
+        onClick={() => onGenerateReport(researchModel)}
         disabled={tickers.length === 0 || isGenerating}
         className="w-full bg-gradient-to-r from-tavily-blue to-tavily-light-blue hover:from-tavily-blue/90 hover:to-tavily-light-blue/90 text-white text-lg py-6"
       >

--- a/UI/src/types/stock-digest.ts
+++ b/UI/src/types/stock-digest.ts
@@ -12,7 +12,7 @@ export interface TavilyStockMetrics {
   sharpe_ratio?: number;
   annualized_cagr?: number;
   latest_open_price?: number;
-  latest_close_price?: number;
+  current_price?: number;
   trading_volume?: number;
   two_year_price_high?: number;
   two_year_price_low?: number;
@@ -29,6 +29,8 @@ export interface StockReport {
   recommendation: string;  // Step 4 from prompt
   risk_assessment: string;  // Step 5 from prompt
   price_outlook: string;  // Step 6 from prompt
+  market_cap?: number;
+  pe_ratio?: number;
   sources: Source[];
   finance_data?: StockFinanceData;
   tavily_metrics?: TavilyStockMetrics;

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -1,464 +1,208 @@
 import logging
 import os
-from datetime import datetime
-from typing import Dict, List
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from typing import Callable, Dict, List, TypeVar
+
 from dotenv import load_dotenv
 from langchain_core.callbacks.manager import dispatch_custom_event
-from langchain_core.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
+from models import (Source, State, StockDigestOutput, StockReport,
+                    TavilyMetrics, get_stock_report_schema)
+from prompts import METRICS_PROMPT, RESEARCH_PROMPT
 from tavily import TavilyClient
-import json
-import re
-from langchain_groq import ChatGroq
-from prompts import get_stock_analysis_prompt, get_market_overview_summary_prompt, get_stock_recommendations_extraction_prompt
-from models import (
-    TargetedResearch, StockReport,
-    StockDigestOutput, State, TavilyMetrics
-)
 
 load_dotenv()
-
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
+
+
+def _create_error_report(ticker: str) -> StockReport:
+    """Create a fallback report when research fails."""
+    return StockReport(
+        ticker=ticker,
+        company_name=ticker,
+        summary=f"Research failed for {ticker}",
+        current_performance="Unable to analyze",
+        key_insights=[],
+        recommendation="Unable to provide recommendation",
+        risk_assessment="Unable to assess risks",
+        price_outlook="Unable to provide outlook",
+        sources=[],
+    )
+
 
 class StockDigestAgent:
-    def __init__(self):
-        self.report_llm = ChatGroq(
-        model="moonshotai/kimi-k2-instruct", api_key=os.getenv("GROQ_API_KEY")
-        )
-
-        self.metrics_llm = ChatGroq(
-        model="llama-3.3-70b-versatile", api_key=os.getenv("GROQ_API_KEY")
-        )
-
+    def __init__(self, research_model: str = "mini"):
+        api_key = os.getenv("OPENAI_API_KEY")
+        self.openai_llm = ChatOpenAI(model="gpt-5-mini", api_key=api_key)
         self.tavily_client = TavilyClient(api_key=os.getenv("TAVILY_API_KEY"))
         self.current_date = datetime.now().strftime("%Y-%m-%d")
-    
-    def fetch_tavily_metrics(self, ticker: str) -> tuple[str, TavilyMetrics]:
+        self.research_model = research_model  # "mini" or "pro"
+
+    def _poll_research(self, request_id: str, poll_interval: int = 10) -> dict:
+        """Poll Tavily research endpoint until completion or failure."""
+        response = self.tavily_client.get_research(request_id)
+        while response["status"] not in ("completed", "failed"):
+            logger.info(f"Research status: {response['status']}... polling in {poll_interval}s")
+            time.sleep(poll_interval)
+            response = self.tavily_client.get_research(request_id)
+            print(response)
+        if response["status"] == "failed":
+            raise RuntimeError(f"Research failed: {response.get('error', 'Unknown error')}")
+        return response
+
+    def _research_ticker(self, ticker: str) -> tuple[str, StockReport]:
+        """Research a single ticker using Tavily Research endpoint."""
+        try:
+            response = self.tavily_client.research(
+                input=RESEARCH_PROMPT.format(ticker=ticker, date=self.current_date),
+                output_schema=get_stock_report_schema(),
+                model=self.research_model
+            )
+            print(response)
+            response = self._poll_research(response["request_id"])
+            result = response["content"]
+
+            sources = [
+                Source(
+                    url=src.get("url", ""),
+                    title=src.get("title", ""),
+                    source=src.get("source"),
+                    domain=src.get("domain"),
+                    published_date=src.get("published_date"),
+                    score=src.get("score", 0.0)
+                )
+                for src in response.get("sources", [])
+            ]
+
+            report = StockReport(
+                ticker=ticker,
+                company_name=result.get("company_name", ticker),
+                summary=result.get("summary", f"Research completed for {ticker}"),
+                current_performance=result.get("current_performance", "Performance data not available"),
+                key_insights=result.get("key_insights", []),
+                recommendation=result.get("recommendation", "Unable to provide recommendation"),
+                risk_assessment=result.get("risk_assessment", "Risk assessment not available"),
+                price_outlook=result.get("price_outlook", "Outlook not available"),
+                market_cap=result.get("market_cap"),
+                pe_ratio=result.get("pe_ratio"),
+                sources=sources,
+            )
+            logger.info(f"Research completed for {ticker}")
+            return ticker, report
+
+        except Exception as e:
+            logger.error(f"Error researching {ticker}: {e}")
+            return ticker, _create_error_report(ticker)
+
+    def _fetch_metrics(self, ticker: str) -> tuple[str, TavilyMetrics]:
+        """Fetch stock metrics using Tavily search and OpenAI extraction."""
         search_results = self.tavily_client.search(
-                query=f"Tell me about the stock {ticker}",
-                search_depth="basic",
-                max_results=5,
-                chunks_per_source=5,
-                topic='finance',
+            query=f"Tell me about the stock {ticker}",
+            search_depth="basic",
+            max_results=5,
+            chunks_per_source=5,
+            topic="finance",
         )
 
-        results = search_results['results']
-        yahoo_results = [x for x in results if x['url'].startswith("https://finance.yahoo.com/quote")]
+        yahoo_results = [
+            r for r in search_results["results"]
+            if r["url"].startswith("https://finance.yahoo.com/quote")
+        ]
 
-        # Format the content for the LLM
         if yahoo_results:
-            # Extract and format the content from Yahoo Finance results
-            formatted_content = []
-            for result in yahoo_results:
-                content = result.get('content', '')
-                title = result.get('title', '')
-                url = result.get('url', '')
-                formatted_content.append(f"Title: {title}\nURL: {url}\nContent: {content}\n")
-            
-            combined_content = "\n".join(formatted_content)
+            content = "\n".join(
+                f"Title: {r.get('title', '')}\nURL: {r.get('url', '')}\nContent: {r.get('content', '')}\n"
+                for r in yahoo_results
+            )
+        else:
+            content = f"No Yahoo Finance data found for {ticker}. Extract from general results."
 
-        metrics_llm = self.metrics_llm.with_structured_output(TavilyMetrics)
-
-        # Create a proper message for the LLM
-        prompt = f"""Extract financial metrics for {ticker} from the following information:
-
-{combined_content}
-
-Please extract the following metrics if available:
-- Sharpe ratio
-- Annualized CAGR
-- Latest open and close prices
-- Trading volume
-- 2-year price high and low
-- Max drawdown
-- Market capitalization
-
-If any metric is not available in the data, set it to None."""
-
-        metrics = metrics_llm.invoke(prompt)
+        metrics = self.openai_llm.with_structured_output(TavilyMetrics).invoke(
+            METRICS_PROMPT.format(ticker=ticker, content=content)
+        )
         return ticker, metrics
 
+    def _run_parallel(
+        self,
+        tickers: List[str],
+        func: Callable[[str], tuple[str, T]],
+        event_name: str,
+        fallback: Callable[[str], T],
+    ) -> Dict[str, T]:
+        """Run a function in parallel for all tickers with progress events."""
+        results: Dict[str, T] = {}
+        total = len(tickers)
 
+        with ThreadPoolExecutor(max_workers=min(total, 4)) as executor:
+            futures = {executor.submit(func, t): t for t in tickers}
+            for i, future in enumerate(as_completed(futures), 1):
+                ticker = futures[future]
+                try:
+                    _, result = future.result()
+                    results[ticker] = result
+                    dispatch_custom_event(event_name, f"Completed {ticker} ({i}/{total})")
+                except Exception as e:
+                    logger.warning(f"Error for {ticker}: {e}")
+                    results[ticker] = fallback(ticker)
+                    dispatch_custom_event(event_name, f"Failed {ticker} ({i}/{total})")
+        return results
 
     def stock_metrics_node(self, state: State) -> Dict:
-        tickers = state["tickers"]
-        tavily_metrics_data = {}
-
-        with ThreadPoolExecutor(max_workers=min(len(tickers), 4)) as executor:
-            future_to_ticker = {
-                executor.submit(self.fetch_tavily_metrics, ticker): ticker
-                for ticker in tickers
-            }
-
-            completed_count = 0
-            for future in as_completed(future_to_ticker):
-                ticker = future_to_ticker[future]
-                try:
-                    _, metrics = future.result()
-                    metrics.market_cap = metrics.latest_open_price * metrics.trading_volume
-                except Exception as e:
-                    logger.warning(f"Error fetching Tavily metrics for {ticker}: {e}")
-                    metrics = TavilyMetrics()
-                tavily_metrics_data[ticker] = metrics
-                completed_count += 1
-                dispatch_custom_event("finance_ticker", f"Completed {ticker} ({completed_count}/{len(tickers)})")
-
-        return {"tavily_metrics": tavily_metrics_data}
-
-    def _fetch_ticker_research(self, ticker: str) -> tuple[str, TargetedResearch]:
-        query = f"{ticker} earnings analyst ratings insider trading technical analysis sector news {self.current_date}"
-        search_results = {"results": []}
-        
-        try:
-            search_results = self.tavily_client.search(
-                query=query,
-                search_depth="advanced",
-                max_results=10,
-                chunks_per_source=5,
-                topic='news',
-                include_domains=["reuters.com", "bloomberg.com", "cnbc.com", "marketwatch.com", "yahoo.com", "seekingalpha.com", "wsj.com", "ft.com"]
-            )
-        except Exception as e:
-            logger.warning(f"Error fetching research for {ticker}: {e}")
-
-        stories = [{
-            'title': r.get('title', ''),
-            'content': r.get('content', ''),
-            'url': r.get('url', ''),
-            'published_date': r.get('published_date', ''),
-            'source': r.get('source', ''),
-            'score': r.get('score', 0),
-            'domain': r.get('domain', ''),
-            'keyword': 'comprehensive'
-        } for r in search_results.get('results', [])]
-
-        categorized = {
-            "earnings_news": [],
-            "analyst_ratings": [],
-            "insider_trading": [],
-            "technical_analysis": [],
-            "sector_news": []
-        }
-
-        keywords = {
-            "earnings_news": {"earnings", "quarterly", "revenue", "profit", "guidance", "results"},
-            "analyst_ratings": {"analyst", "rating", "target", "upgrade", "downgrade", "recommendation"},
-            "insider_trading": {"insider", "sec", "filing", "executive", "form 4"},
-            "technical_analysis": {"technical", "support", "resistance", "rsi", "macd", "chart"}
-        }
-
-        for story in stories:
-            content = (story['content'] + ' ' + story['title']).lower()
-            assigned = False
-            for category, keys in keywords.items():
-                if any(k in content for k in keys):
-                    categorized[category].append(story)
-                    assigned = True
-                    break
-            if not assigned:
-                categorized["sector_news"].append(story)
-
-        research = TargetedResearch(ticker=ticker, **categorized)
-        logger.info(f"Research completed for {ticker} with {len(stories)} stories")
-        return ticker, research
-
-    def targeted_research_node(self, state: State) -> Dict:
-        dispatch_custom_event("targeted_research_status", "Performing comprehensive research...")
-        tickers = state["tickers"]
-        research_data = {}
-
-        # Parallelize ticker research
-        with ThreadPoolExecutor(max_workers=min(len(tickers), 4)) as executor:
-            # Submit all tasks
-            future_to_ticker = {
-                executor.submit(self._fetch_ticker_research, ticker): ticker 
-                for ticker in tickers
-            }
-            
-            # Process completed tasks
-            completed_count = 0
-            for future in as_completed(future_to_ticker):
-                ticker = future_to_ticker[future]
-                try:
-                    ticker, research = future.result()
-                    research_data[ticker] = research
-                    completed_count += 1
-                    dispatch_custom_event("targeted_research_ticker", f"Completed {ticker} ({completed_count}/{len(tickers)})")
-                except Exception as e:
-                    logger.error(f"Error researching ticker {ticker}: {e}")
-                    # Create a default research object for failed ticker
-                    research_data[ticker] = TargetedResearch(
-                        ticker=ticker,
-                        earnings_news=[],
-                        analyst_ratings=[],
-                        insider_trading=[],
-                        technical_analysis=[],
-                        sector_news=[]
-                    )
-                    completed_count += 1
-                    dispatch_custom_event("targeted_research_ticker", f"Failed {ticker} ({completed_count}/{len(tickers)})")
-
-        return {"targeted_research": research_data}
-
-    def _analyze_ticker(self, ticker: str, targeted_research: Dict, finance_data: Dict, tavily_metrics: Dict, all_stories: List) -> tuple[str, StockReport]:
-        research = targeted_research.get(ticker, {})
-        finance = finance_data.get(ticker)
-        ticker_tavily_metrics = tavily_metrics.get(ticker)
-        ticker_stories = [story for t, story in all_stories if t == ticker]
-
-        try:
-            structured_llm = self.report_llm.with_structured_output(StockReport)
-            prompt = get_stock_analysis_prompt(ticker, research, ticker_stories, self.current_date)
-            report = structured_llm.invoke(prompt)
-            
-            # The report is already a StockReport object, just add the additional fields
-            if hasattr(report, 'model_dump'):
-                report_dict = report.model_dump()
-            else:
-                report_dict = dict(report)
-            
-            report_dict['sources'] = ticker_stories
-            report_dict['finance_data'] = finance
-            report_dict['tavily_metrics'] = ticker_tavily_metrics
-            return ticker, StockReport(**report_dict)
-        except Exception as e:
-            logger.warning(f"Groq model failed for ticker {ticker}: {e}.")
-
-    def analysis_formatter_node(self, state: State) -> Dict:
-        dispatch_custom_event("gemini_analysis_status", "Generating structured stock reports...")
-        tickers = state["tickers"]
-        targeted_research = state.get("targeted_research", {})
-        finance_data = state.get("finance_data", {})
-        tavily_metrics = state.get("tavily_metrics", {})
-        
-
-        all_stories = []
-        for ticker in tickers:
-            research = targeted_research.get(ticker, {})
-            if isinstance(research, dict):
-                research_dict = research
-            elif hasattr(research, 'model_dump'):
-                research_dict = research.model_dump()
-            else:
-                research_dict = {}
-            
-            for category, stories in research_dict.items():
-                if category != 'ticker' and stories:
-                    all_stories.extend((ticker, story.copy()) for story in stories)
-
-        reports = {}
-        
-        # Parallelize ticker analysis
-        with ThreadPoolExecutor(max_workers=min(len(tickers), 4)) as executor:
-            # Submit all tasks
-            future_to_ticker = {
-                executor.submit(self._analyze_ticker, ticker, targeted_research, finance_data, tavily_metrics, all_stories): ticker 
-                for ticker in tickers
-            }
-            
-            # Process completed tasks
-            completed_count = 0
-            for future in as_completed(future_to_ticker):
-                ticker = future_to_ticker[future]
-                try:
-                    ticker, report = future.result()
-                    reports[ticker] = report
-                    completed_count += 1
-                    dispatch_custom_event("analysis_ticker", f"Completed {ticker} ({completed_count}/{len(tickers)})")
-                except Exception as e:
-                    logger.error(f"Error analyzing ticker {ticker}: {e}")
-                    # Create a default report for failed ticker
-                    reports[ticker] = StockReport(
-                        ticker=ticker,
-                        company_name=ticker,
-                        summary=f"Analysis failed for {ticker}",
-                        current_performance="Unable to analyze",
-                        key_insights=[],
-                        recommendation="Unable to provide recommendation",
-                        risk_assessment="Unable to assess risks",
-                        price_outlook="Unable to provide outlook",
-                        sources=[],
-                        finance_data=finance_data.get(ticker),
-                        tavily_metrics=tavily_metrics.get(ticker)
-                    )
-                    completed_count += 1
-                    dispatch_custom_event("analysis_ticker", f"Failed {ticker} ({completed_count}/{len(tickers)})")
-
-        return {
-            "structured_reports": StockDigestOutput(
-                reports=reports,
-                market_overview="",
-                generated_at=datetime.now().isoformat(),
-                ticker_suggestions={}
-            )
-        }
-
-    def market_overview_summary_node(self, state: State) -> Dict:
-        dispatch_custom_event("market_overview_summary_status", "Creating detailed market overview...")
-        structured_reports = state["structured_reports"]
-        finance_data = state.get("finance_data", {})
-
-        comprehensive_texts = []
-        for ticker, report in structured_reports.reports.items():
-            finance = finance_data.get(ticker)
-            company = finance.company_name if finance else ticker
-            market_cap = f"${finance.market_cap/1e9:.2f}B" if finance and finance.market_cap else "N/A"
-            text = (
-                f"TICKER: {ticker}\n"
-                f"COMPANY: {company}\n"
-                f"CURRENT PRICE: ${finance.current_price if finance else 'N/A'}\n"
-                f"MARKET CAP: {market_cap}\n"
-                f"SUMMARY: {report.summary}\n"
-                f"CURRENT PERFORMANCE: {report.current_performance}\n"
-                f"KEY INSIGHTS: {report.key_insights}\n"
-                f"RECOMMENDATION: {report.recommendation}\n"
-                f"RISK ASSESSMENT: {report.risk_assessment}\n"
-                f"PRICE OUTLOOK: {report.price_outlook}\n"
-            )
-            comprehensive_texts.append(text)
-
-        concatenated = "\n\n".join(comprehensive_texts)
-        refine_prompt = PromptTemplate(input_variables=["text"], template=get_market_overview_summary_prompt())
-        
-        # Direct report_llm call using the prompt
-        overview_result = self.report_llm.invoke(refine_prompt.format(text=concatenated))
-
-        updated_reports = StockDigestOutput(
-            reports=structured_reports.reports,
-            market_overview=overview_result.content,
-            generated_at=structured_reports.generated_at,
-            ticker_suggestions=structured_reports.ticker_suggestions
+        """Fetch stock metrics for all tickers."""
+        dispatch_custom_event("stock_metrics_status", "Fetching stock metrics...")
+        metrics = self._run_parallel(
+            state["tickers"],
+            self._fetch_metrics,
+            "finance_ticker",
+            lambda _: TavilyMetrics(),
         )
-        return {"structured_reports": updated_reports}
+        return {"tavily_metrics": metrics}
 
-    def stock_recommendations_research_node(self, state: State) -> Dict:
-        dispatch_custom_event("stock_recommendations_status", "Finding current stock recommendations...")
-        
-        # Get user's existing tickers to exclude them from recommendations
-        user_tickers = state["tickers"]
-        user_tickers_str = " ".join(user_tickers)
-        
-        # Create a query that excludes user's existing tickers and focuses on finding new opportunities
-        query = f"top stock picks 2025 analyst buy recommendations emerging growth stocks undervalued opportunities NOT {user_tickers_str}"
-        
-        try:
-            search_results = self.tavily_client.search(
-                query=query,
-                search_depth="advanced",
-                topic="news",
-                max_results=8,  # Increased to get more diverse results
-            )
-            
-            # Extract text from search results
-            answer_text = search_results.get("answer", "")
-            if not answer_text and "results" in search_results:
-                results_content = []
-                for result in search_results["results"][:6]:
-                    if "content" in result:
-                        results_content.append(result["content"])
-                answer_text = " ".join(results_content)
-            
-            logger.info(f"Returning state with text length: {len(answer_text)}")
-            
-            return {"recommendations_raw_text": answer_text}
-            
-        except Exception as e:
-            logger.error(f"Error in stock recommendations research: {e}")
-            return {"recommendations_raw_text": ""}
+    def stock_research_node(self, state: State) -> Dict:
+        """Research all tickers using Tavily Research endpoint."""
+        dispatch_custom_event("stock_research_status", "Performing deep research on stocks...")
+        reports = self._run_parallel(
+            state["tickers"],
+            self._research_ticker,
+            "stock_research_ticker",
+            _create_error_report,
+        )
+        return {"structured_reports": StockDigestOutput(reports=reports)}
 
-    def recommendation_formatting_node(self, state: State) -> Dict:
-        dispatch_custom_event("recommendation_formatting_status", "Formatting stock recommendations...")
-        
-        raw_text = state.get("recommendations_raw_text", "")
-        user_tickers = state["tickers"]  # Get user's existing tickers to exclude them
-        logger.info(f"Formatting node received text length: {len(raw_text)}")
-        
-        ticker_suggestions = {}
-        
-        if raw_text and len(raw_text.strip()) >= 50:
-            extraction_prompt = get_stock_recommendations_extraction_prompt(raw_text, exclude_tickers=user_tickers)
-            response = self.report_llm.invoke(extraction_prompt)
-            response_text = str(response.content)
-            # Extract JSON from response
-            json_match = re.search(r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}', response_text, re.DOTALL) or re.search(r'\{.*\}', response_text, re.DOTALL)
-            
-            if json_match:
-                try:
-                    extracted_data = json.loads(json_match.group())
-                    logger.info(f"Successfully parsed JSON")
-                    
-                    # Validate and extract tickers from JSON, excluding user's existing tickers
-                    for ticker, reason in extracted_data.items():
-                        if (re.match(r'^[A-Z]{2,5}$', ticker) and reason.strip() and 
-                            ticker not in user_tickers):  # Exclude user's existing tickers
-                            ticker_suggestions[ticker] = reason.strip()
-                except json.JSONDecodeError as e:
-                    logger.error(f"Failed to parse JSON from response: {e}")
-                    logger.error(f"Response text: {response_text}")
-        
-        logger.info(f"Final ticker suggestions (excluding user's {user_tickers})")
-        
-        return {"ticker_suggestions": ticker_suggestions}
-
-    def final_assembly_node(self, state: State) -> Dict:
-        """Combine structured reports with ticker suggestions"""
-        dispatch_custom_event("final_assembly_status", "Assembling final report...")
-        
-        structured_reports = state.get("structured_reports")
-        ticker_suggestions = state.get("ticker_suggestions", {})
-        
-        if structured_reports:
-            # Update the structured_reports with the ticker_suggestions
-            updated_reports = StockDigestOutput(
-                reports=structured_reports.reports,
-                market_overview=structured_reports.market_overview,
-                generated_at=structured_reports.generated_at,
-                ticker_suggestions=ticker_suggestions
-            )
-            return {"structured_reports": updated_reports}
-        else:
-            # Fallback if structured_reports is not available
-            return {"structured_reports": StockDigestOutput(
-                reports={},
-                market_overview="",
-                generated_at=datetime.now().isoformat(),
-                ticker_suggestions=ticker_suggestions
-            )}
+    def merge_metrics_node(self, state: State) -> Dict:
+        """Merge Tavily metrics into stock reports."""
+        structured_reports = state["structured_reports"]
+        tavily_metrics = state.get("tavily_metrics", {})
+        for ticker, report in structured_reports.reports.items():
+            if ticker in tavily_metrics:
+                report.tavily_metrics = tavily_metrics[ticker]
+        return {"structured_reports": structured_reports}
 
     def build_graph(self):
-        graph_builder = StateGraph(State)
-        graph_builder.add_node("StockMetrics", self.stock_metrics_node)
-        graph_builder.add_node("TargetedResearch", self.targeted_research_node)
-        graph_builder.add_node("AnalysisFormatter", self.analysis_formatter_node)
-        graph_builder.add_node("StockRecommendationsResearch", self.stock_recommendations_research_node)
-        graph_builder.add_node("RecommendationFormatting", self.recommendation_formatting_node)
-        graph_builder.add_node("MarketOverviewSummary", self.market_overview_summary_node)
-        graph_builder.add_node("FinalAssembly", self.final_assembly_node)
+        """Build the LangGraph workflow."""
+        graph = StateGraph(State)
+        graph.add_node("StockResearch", self.stock_research_node)
+        graph.add_node("StockMetrics", self.stock_metrics_node)
+        graph.add_node("MergeMetrics", self.merge_metrics_node)
 
-        # Create parallel execution by running both nodes from START
-        graph_builder.add_edge(START, "StockMetrics")
-        graph_builder.add_edge("StockMetrics", "AnalysisFormatter")
+        # Run research and metrics in parallel, then merge
+        graph.add_edge(START, "StockResearch")
+        graph.add_edge(START, "StockMetrics")
+        graph.add_edge("StockResearch", "MergeMetrics")
+        graph.add_edge("StockMetrics", "MergeMetrics")
+        graph.add_edge("MergeMetrics", END)
 
-        graph_builder.add_edge(START, "TargetedResearch")
-        graph_builder.add_edge("TargetedResearch", "AnalysisFormatter")
-        graph_builder.add_edge("AnalysisFormatter", "MarketOverviewSummary")
-        
-        graph_builder.add_edge(START, "StockRecommendationsResearch")
-        graph_builder.add_edge("StockRecommendationsResearch", "RecommendationFormatting")
-        graph_builder.add_edge("RecommendationFormatting", "MarketOverviewSummary")
-
-        graph_builder.add_edge("MarketOverviewSummary", "FinalAssembly")        
-        
-        graph_builder.add_edge("FinalAssembly", END)
-
-        return graph_builder.compile()
+        return graph.compile()
 
     async def run_digest(self, tickers: List[str]) -> StockDigestOutput:
+        """Run the stock digest workflow for given tickers."""
         logger.info(f"Starting stock digest for tickers: {tickers}")
         graph = self.build_graph()
-        initial_state = {"tickers": tickers, "date": self.current_date}
-        final_state = await graph.ainvoke(initial_state)
+        final_state = await graph.ainvoke({"tickers": tickers, "date": self.current_date})
         return final_state["structured_reports"]

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -130,13 +130,11 @@ class StockDigestAgent:
             if r["url"].startswith("https://finance.yahoo.com/quote")
         ]
 
-        if yahoo_results:
-            content = "\n".join(
-                f"Title: {r.get('title', '')}\nURL: {r.get('url', '')}\nContent: {r.get('content', '')}\n"
-                for r in yahoo_results
-            )
-        else:
-            content = f"No Yahoo Finance data found for {ticker}. Extract from general results."
+        results_to_use = yahoo_results if yahoo_results else search_results["results"]
+        content = "\n".join(
+            f"Title: {r.get('title', '')}\nURL: {r.get('url', '')}\nContent: {r.get('content', '')}\n"
+            for r in results_to_use
+        )
 
         metrics = self.openai_llm.with_structured_output(TavilyMetrics).invoke(
             METRICS_PROMPT.format(ticker=ticker, content=content)

--- a/backend/app.py
+++ b/backend/app.py
@@ -35,6 +35,10 @@ async def ping():
 @app.post("/api/stock-digest")
 async def analyze_stocks(request: StockDigestRequest):
     try:
+        # Validate tickers is non-empty
+        if not request.tickers:
+            raise HTTPException(status_code=400, detail="tickers must be a non-empty list")
+            
         # Validate research model
         if request.research_model not in ("mini", "pro"):
             raise HTTPException(status_code=400, detail="research_model must be 'mini' or 'pro'")

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,13 +1,13 @@
+import os
 from typing import List
 
+import uvicorn
+from agent import StockDigestAgent
+from dotenv import load_dotenv
 from fastapi import Cookie, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-import uvicorn
-from dotenv import load_dotenv
-from agent import StockDigestAgent
-import os
 
 app = FastAPI()
 
@@ -17,9 +17,7 @@ load_dotenv()
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        os.getenv("VITE_APP_URL") if os.getenv("VITE_APP_URL") else []
-    ],
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -27,6 +25,7 @@ app.add_middleware(
 
 class StockDigestRequest(BaseModel):
     tickers: List[str]
+    research_model: str = "mini"  # "mini" or "pro"
 
 @app.get("/")
 async def ping():
@@ -36,37 +35,18 @@ async def ping():
 @app.post("/api/stock-digest")
 async def analyze_stocks(request: StockDigestRequest):
     try:
-        # Create and initialize the stock digest agent with the provided API key
-        agent = StockDigestAgent()
+        # Validate research model
+        if request.research_model not in ("mini", "pro"):
+            raise HTTPException(status_code=400, detail="research_model must be 'mini' or 'pro'")
+        
+        # Create and initialize the stock digest agent
+        agent = StockDigestAgent(research_model=request.research_model)
 
         # Run the stock digest workflow
         final_state = await agent.run_digest(request.tickers)
         
-        # Convert the result to a dictionary for JSON serialization
-        response_data = {
-            "reports": {},
-            "generated_at": final_state.generated_at,
-            "market_overview": final_state.market_overview,
-            "ticker_suggestions": final_state.ticker_suggestions,
-        }
-        
-        # Convert each stock report to a dictionary
-        for ticker, report in final_state.reports.items():
-            response_data["reports"][ticker] = {
-                "ticker": report.ticker,
-                "company_name": report.company_name,
-                "summary": report.summary,
-                "current_performance": report.current_performance,
-                "key_insights": report.key_insights,
-                "recommendation": report.recommendation,
-                "risk_assessment": report.risk_assessment,
-                "price_outlook": report.price_outlook,
-                "sources": report.sources,
-                "finance_data": report.finance_data,
-                "tavily_metrics": report.tavily_metrics
-            }
-        
-        return response_data
+        # Convert to dict for JSON serialization
+        return final_state.model_dump()
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Dict, List
 from typing import Optional as OptionalType
+
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
@@ -8,47 +9,21 @@ from typing_extensions import TypedDict
 class Source(BaseModel):
     url: str = Field(description="URL of the source")
     title: str = Field(description="Title of the source")
-    date: OptionalType[str] = Field(default=None, description="Date of the source")
+    source: OptionalType[str] = Field(default=None, description="Source name/publisher")
+    domain: OptionalType[str] = Field(default=None, description="Domain of the source")
+    published_date: OptionalType[str] = Field(default=None, description="Publication date of the source")
+    score: OptionalType[float] = Field(default=0.0, description="Relevance score")
 
-
-class StockFinanceData(BaseModel):
-    ticker: str = Field(description="Stock ticker symbol")
-    current_price: float = Field(description="Current stock price")
-    market_cap: OptionalType[float] = Field(default=None, description="Market capitalization")
-    company_name: str = Field(description="Company name")
-    price_to_earnings_ratio: OptionalType[str] = Field(default=None, description="P/E ratio")
-    eps: OptionalType[str] = Field(default=None, description="Earnings per share")
-    dividend_yield: OptionalType[str] = Field(default=None, description="Dividend yield")
 
 class TavilyMetrics(BaseModel):
+    annualized_cagr: OptionalType[float] = Field(default=None, description="Annualized CAGR percentage")
     sharpe_ratio: OptionalType[float] = Field(default=None, description="Sharpe ratio")
-    annualized_cagr: OptionalType[float] = Field(default=None, description="Annualized CAGR")
+    max_drawdown: OptionalType[float] = Field(default=None, description="Maximum drawdown percentage")
+    two_year_price_high: OptionalType[float] = Field(default=None, description="2-year price high in dollars")
+    two_year_price_low: OptionalType[float] = Field(default=None, description="2-year price low in dollars")
     latest_open_price: OptionalType[float] = Field(default=None, description="Latest open price")
-    latest_close_price: OptionalType[float] = Field(default=None, description="Latest close price")
+    current_price: OptionalType[float] = Field(default=None, description="Current/latest stock price")
     trading_volume: OptionalType[float] = Field(default=None, description="Trading volume")
-    two_year_price_high: OptionalType[float] = Field(default=None, description="2-year price high")
-    two_year_price_low: OptionalType[float] = Field(default=None, description="2-year price low")
-    max_drawdown: OptionalType[float] = Field(default=None, description="Max drawdown")
-    market_cap: OptionalType[float] = Field(default=None, description="Market capitalization")
-    
-
-class StockResearch(BaseModel):
-    ticker: str = Field(description="Stock ticker symbol")
-    news_summary: str = Field(description="Summary of recent news")
-    key_developments: List[str] = Field(default_factory=list, description="Key developments")
-    analyst_sentiment: str = Field(description="Analyst sentiment")
-    risk_factors: List[str] = Field(default_factory=list, description="Risk factors")
-    price_targets: OptionalType[str] = Field(default=None, description="Price targets")
-    sources: List[Source] = Field(default_factory=list, description="Sources of information")
-
-
-class TargetedResearch(BaseModel):
-    ticker: str = Field(description="Stock ticker symbol")
-    earnings_news: List[Dict] = Field(default_factory=list, description="Earnings related news")
-    analyst_ratings: List[Dict] = Field(default_factory=list, description="Analyst ratings")
-    insider_trading: List[Dict] = Field(default_factory=list, description="Insider trading information")
-    technical_analysis: List[Dict] = Field(default_factory=list, description="Technical analysis")
-    sector_news: List[Dict] = Field(default_factory=list, description="Sector related news")
 
 
 class StockReport(BaseModel):
@@ -60,32 +35,38 @@ class StockReport(BaseModel):
     recommendation: str = Field(description="Investment recommendation")
     risk_assessment: str = Field(description="Risk assessment")
     price_outlook: str = Field(description="Price outlook")
+    market_cap: OptionalType[float] = Field(default=None, description="Market capitalization in dollars")
+    pe_ratio: OptionalType[float] = Field(default=None, description="Price-to-earnings ratio")
     sources: List[Source] = Field(default_factory=list, description="Sources of information")
-    finance_data: OptionalType[StockFinanceData] = Field(default=None, description="Financial data")
-    tavily_metrics: OptionalType[TavilyMetrics] = Field(default=None, description="Tavily financial metrics")
+    tavily_metrics: OptionalType[TavilyMetrics] = Field(default=None, description="Tavily stock metrics")
 
 
 class StockDigestOutput(BaseModel):
     reports: Dict[str, StockReport] = Field(default_factory=dict, description="Stock reports by ticker")
     generated_at: str = Field(default_factory=lambda: datetime.now().isoformat(), description="Generation timestamp")
-    market_overview: OptionalType[str] = Field(default=None, description="Market overview")
-    ticker_suggestions: Dict[str, str] = Field(description="Suggested tickers with reasons")
-
-
-class PDFData(BaseModel):
-    pdf_base64: str = Field(description="Base64 encoded PDF data")
-    filename: str = Field(description="PDF filename")
 
 
 class State(TypedDict):
     tickers: List[str]
-    finance_data: Dict[str, StockFinanceData]
-    tavily_metrics: Dict[str, TavilyMetrics]
-    research_data: Dict[str, StockResearch]
-    targeted_research: Dict[str, TargetedResearch]
-    all_news_stories: List[tuple]
     structured_reports: StockDigestOutput
-    pdf_data: OptionalType[PDFData]
+    tavily_metrics: Dict[str, TavilyMetrics]
     date: str
-    recommendations_raw_text: str
-    ticker_suggestions: Dict[str, str] 
+
+def get_stock_report_schema() -> dict:
+    """Generate Tavily output schema from StockReport model, excluding ticker, sources, and tavily_metrics."""
+    schema = StockReport.model_json_schema()
+    excluded = ("ticker", "sources", "tavily_metrics")
+    properties = {}
+    for k, v in schema.get("properties", {}).items():
+        if k in excluded:
+            continue
+        # Handle Optional types that generate anyOf schema
+        if "anyOf" in v:
+            # Extract the non-null type from anyOf
+            for option in v["anyOf"]:
+                if option.get("type") != "null":
+                    v = {**option, "description": v.get("description", "")}
+                    break
+        properties[k] = v
+    required = [f for f in schema.get("required", []) if f not in excluded]
+    return {"properties": properties, "required": required}

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -1,142 +1,19 @@
-def get_stock_analysis_prompt(ticker: str, research_data: dict | object, ticker_stories: list, current_date: str) -> str:
-    # Handle both dict and Pydantic model types
-    if isinstance(research_data, dict):
-        research_str = str(research_data)
-    elif hasattr(research_data, 'model_dump'):
-        research_str = str(research_data.model_dump())  # type: ignore
-    else:
-        research_str = str(research_data)
-    
-    return f"""
-    You are a professional portfolio analyst providing concise updates on stock positions based on recent news and market developments.
-    
-    Analyze the following data for {ticker}:
-    
-    Research Data: {research_str}
-    
-    Recent News Stories for {ticker}:
-    {chr(10).join([f"Title: {story['title']}{chr(10)}Content: {story['content']}{chr(10)}Source: {story['source']}{chr(10)}Date: {story['published_date']}{chr(10)}Relevance Score: {story.get('score', 'N/A')}{chr(10)}" for story in ticker_stories[:5]])}
-    
-    Current date: {current_date}
-    
-    Create a portfolio-focused report with the following fields:
-    1. summary: In 5-6 sentences, summarize the most important details from the research data for this stock along with other important market details.
-    2. current_performance: 2-3 sentences on recent price action and key metrics
-    3. key_insights: List of 5-8 important insights from the latest news. Focus on specific events, earnings, analyst insights, analyst actions, or significant changes with the market or business related to this stock. Include relevant analyst insights mentioning specific company or analyst names when available.
-    4. recommendation: Investment recommendation (Buy/Hold/Sell with brief reasoning)
-    5. risk_assessment: 2-3 sentences identifying key risks from news
-    6. price_outlook: 1-2 sentences on near-term expectations
+RESEARCH_PROMPT = """Do a comprehensive stock analysis for {ticker} as of {date}:
+- Current stock price and recent price performance
+- Market capitalization and key financial metrics
+- Latest earnings results and guidance
+- Recent news and developments
+- Analyst ratings, upgrades/downgrades, and price targets
+- Key risks and opportunities
+- Investment recommendation with reasoning
+Focus on all the recent updates about the company.
+"""
 
-    **Key-Insights formatting rules**  
-    • Return as separate bullet strings.  
-    • Be explicit: numbers, dates, names.  
-    • Prioritise high-relevance stories and analysts.
-    
-    Provide the ticker symbol as: {ticker}
-    Use a generic company name if not available in the data.
-    """
+METRICS_PROMPT = """Extract financial metrics for {ticker} from the following information:
 
+{content}
 
-def get_market_overview_prompt(tickers: list, all_news_stories: list, current_date: str) -> str:
-    return f"""
-    You are a senior market analyst creating a concise market overview that connects individual stock developments to broader market trends.
-    
-    Analyze the following news stories from the past few days for these stocks: {', '.join(tickers)}
-    
-    News Stories Summary:
-    {chr(10).join([f"Ticker: {ticker}{chr(10)}Title: {story['title']}{chr(10)}Content: {story['content'][:300]}...{chr(10)}Source: {story['source']}{chr(10)}Date: {story['published_date']}{chr(10)}" for ticker, story in all_news_stories[:15]])}
-    
-    Current date: {current_date}
-    
-    Create a concise market overview (5-7 sentences) covering overall market environemnt, trends and sentiment.
-    
-    """
-
-def get_stock_metrics_prompt(extract_results: str) -> str:
-    return f"""
-    Given this website data extract the following metrics:
-    {extract_results}
-    
-    - Current Price or price
-    - Market Cap
-    - Company Name
-    - Price to Earnings Ratio or PE Ratio
-    - EPS (Earnings Per Share)
-    - Dividend or Dividend Yield percentage
-    """
-
-def get_market_overview_summary_prompt() -> str:
-    return """
-    You are a senior portfolio strategist writing a polished, professional market overview for an investor.
-
-    Write a comprehensive market analysis and portfolio overview using the provided research data.
-
-    Your analysis should include TWO key components:
-
-    1. MARKET OVERVIEW: Analyze broader market conditions, trends, and sentiment. Identify key market drivers, sector performance, and macroeconomic factors affecting the overall investment landscape.
-
-    2. PORTFOLIO ANALYSIS: Evaluate how the current market environment impacts portfolio positioning, risk exposure, and strategic opportunities. Assess portfolio performance relative to market conditions and identify areas for optimization.
-
-    Focus on connecting individual stock developments to broader market trends, providing context for how portfolio holdings relate to the overall market environment. Address current market positioning, potential risks, and strategic opportunities.
-
-    Use clear, professional language suitable for an investor newsletter. Ensure each paragraph flows naturally into the next, creating a cohesive narrative that bridges market analysis with portfolio implications.
-
-    Analyze and incorporate the following research data:
-
-    GUIDELINES:
-    - Structure your response in 1-3 well-developed paragraphs with new lines
-    - It must be only 150-200 words total!
-    - Balance market overview with portfolio analysis
-    - Connect market trends to portfolio implications
-
-    {text}
-    """
-
-def get_stock_recommendations_prompt() -> str:
-    return """
-    You are a senior investment analyst tasked with identifying 6 promising stock opportunities for portfolio diversification.
-    
-    Research and analyze current market conditions, sector trends, and emerging opportunities to recommend 6 stocks that offer strong growth potential, solid fundamentals, or strategic positioning.
-    
-    Focus on:
-    - Companies with strong recent performance or positive catalysts
-    - Undervalued stocks with growth potential
-    - Emerging market leaders or disruptors
-    - Stocks with favorable analyst coverage or upgrades
-    - Companies with upcoming catalysts (earnings, product launches, etc.)
-    
-    Provide detailed reasoning for each recommendation including:
-    - Key business drivers and competitive advantages
-    - Recent developments or catalysts
-    - Financial strength and growth prospects
-    - Risk factors to consider
-    
-    Return exactly 6 stock recommendations with comprehensive analysis for each.
-    """
-
-def get_stock_recommendations_extraction_prompt(raw_text: str, exclude_tickers: list | None = None) -> str:
-    exclude_text = ""
-    if exclude_tickers:
-        exclude_text = f"\n\nIMPORTANT: Do NOT include any of these tickers in your recommendations: {', '.join(exclude_tickers)}"
-    
-    return f"""
-    Extract exactly 6 stock ticker symbols and their detailed investment reasons from the following text.
-    Only return actual stock ticker symbols (2-5 letter codes) and specific, detailed reasons.
-    
-    Text: {raw_text}{exclude_text}
-    
-    Return as a JSON object with exactly 6 ticker symbols as keys and detailed reasons as values.
-    Example format: {{
-        "ticker": "reason (2-3 sentences)",
-        "ticker": "reason (2-3 sentences)",
-        "ticker": "reason (2-3 sentences)",
-        "ticker": "reason (2-3 sentences)",
-        "ticker": "reason (2-3 sentences)",
-        "ticker": "reason (2-3 sentences)",
-        }}
-    
-    IMPORTANT: Return exactly 6 stock recommendations, no more, no less.
-    Make the reasons specific and detailed (2-3 sentences) rather than generic phrases like "Top pick" or "Key stock".
-    Only include real stock tickers, not words like "AI", "Tech", etc.
-    Focus on concrete business drivers, financial metrics, or strategic advantages.
-    """
+Extract these metrics if available (set to None if unavailable):
+- Sharpe ratio, Annualized CAGR, Max drawdown
+- Latest open/close prices, Current price, Trading volume
+- 2-year price high and low"""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,11 +2,11 @@ fastapi>=0.109.1
 uvicorn==0.27.0
 pydantic==2.11.7
 pydantic-settings==2.9.1
-langchain-groq==0.3.2
+langchain-openai==0.3.23
 langchain>=0.0.300
-langchain-core==0.3.65
+langchain-core>=0.3.81
 langgraph==0.4.8
-tavily-python==0.5.4
+tavily-python==0.7.17
 python-dotenv==1.0.0
 typing_extensions==4.13.2
 python-jose


### PR DESCRIPTION
- Now the market research uses the research endpoint for all the heavy lifting
- It puts in a schema with all the different UI fields populates it with relevant data grounded in web data and returns the sources

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces schema-driven research via Tavily and refactors the workflow for clarity and performance.
> 
> - Backend: New LangGraph flow (`StockResearch` + `StockMetrics` in parallel → `MergeMetrics`) with async polling of Tavily Research; replaces Groq with OpenAI; adds prompts; expands `Source` and `TavilyMetrics` (adds `current_price`, removes `latest_close_price`); `StockReport` gains optional `market_cap`/`pe_ratio`; API `POST /api/stock-digest` now accepts `research_model` ("mini"/"pro"), enables CORS `*`, returns `model_dump()` of structured reports
> - Frontend: `TickerInput` adds Mini/Pro research model switch; `DailyDigestReport` removes tabs/market overview/recommendations, streamlines report view, displays current price/market cap/P‑E; sources list shows date/score/domain; TS types aligned with backend changes
> - Docs/Deps: README overhauled to document Tavily Research schema workflow; dependencies updated to `langchain-openai` and newer `tavily-python`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75b6b12ea15301ef927cfaa70e9f43606dba2203. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->