### PR TITLE
fix: bump dompurify to 3.3.2

### DIFF
--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -3940,11 +3940,14 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }


### PR DESCRIPTION
## Summary
- Bumps `dompurify` from 3.3.1 to 3.3.2 in `UI/package-lock.json`
- Transitive dependency via `jspdf`
- Fixes Dependabot alert [GHSA-v2wj-7wpq-c8vv](https://github.com/advisories/GHSA-v2wj-7wpq-c8vv) — DOMPurify XSS vulnerability (medium severity)

## Test plan
- [ ] Verify UI build succeeds
- [ ] Confirm PDF export still works