### PR TITLE
fix: bump langchain-openai + python-dotenv + dompurify (medium CVEs)

### DIFF
--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -3940,14 +3940,11 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,11 +2,11 @@ fastapi>=0.109.1
 uvicorn==0.27.0
 pydantic==2.11.7
 pydantic-settings==2.9.1
-langchain-openai==0.3.23
+langchain-openai==1.1.14
 langchain>=0.0.300
 langchain-core>=0.3.81
 langgraph==1.0.10rc1
 tavily-python==0.7.17
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 typing_extensions==4.13.2
 python-jose


### PR DESCRIPTION
## Summary
Consolidates closed Dependabot PRs #29 and #30:
- backend: langchain-openai → 1.1.14, python-dotenv → 1.2.2
- UI: dompurify → 3.4.1

## Test plan
- [ ] Backend starts
- [ ] UI builds