### PR TITLE
fix: bump vite to 7.3.5 (high-severity CVE)

### DIFF
--- a/UI/package-lock.json
+++ b/UI/package-lock.json
@@ -6289,9 +6289,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Bumps vite from 7.3.2 to 7.3.5 in UI/package-lock.json (within the existing `^7.3.2` range; only the lockfile changes)
- Fixes: high-severity vulnerability in vite

## Test plan
- `npm ci && npm run build` was run. vite 7.3.5 transforms all 1054 modules successfully, then the build fails on a **pre-existing, unrelated** issue: `Rollup failed to resolve import "/logo_with_text.svg" from Header.tsx` — that asset is missing from the repo and the failure reproduces on main (this branch only changes the lockfile). The vite upgrade itself is clean.
- [ ] Reviewer: the missing-asset build break is independent of this security bump.